### PR TITLE
Updated contains, startswith, and endswith to handle simple '*' and '…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ serde_yml = "0.0.12"
 strum = { version = "0.26.3", features = ["derive"] }
 thiserror = "1.0.64"
 serde_json = { version = "1.0.132", optional = true }
+lazy_static = "*"
 
 [dev-dependencies]
 walkdir = "2.5.0"

--- a/src/field.rs
+++ b/src/field.rs
@@ -141,21 +141,22 @@ impl Field {
                     .map(FieldValue::String)
                     .collect();
             }
-            None => {}
-        }
-        if !self.modifier.cased {
-            self.values = self
-                .values
-                .iter()
-                .map(|val| FieldValue::String(value_to_lowercase(val)))
-                .collect()
+            None => {
+                if !self.modifier.cased {
+                    self.values = self
+                        .values
+                        .iter()
+                        .map(|val| FieldValue::String(value_to_lowercase(val)))
+                        .collect()
+                }
+            }
         }
 
         Ok(())
     }    
 
     pub(crate) fn compare(&self, target: &FieldValue, value: &FieldValue) -> bool {
-        let t = if self.modifier.cased { // was case insensitive matching specified?
+        let t = if self.modifier.cased { // was case sensitive matching specified?
             target
         } else {
             &FieldValue::String(target.value_to_string().to_lowercase())

--- a/src/field.rs
+++ b/src/field.rs
@@ -160,7 +160,7 @@ impl Field {
                 if value == &FieldValue::Boolean(true) { // field exists
                     return true
                 } else if value == &FieldValue::Boolean(false) 
-                    && target == &FieldValue::Boolean(true) { // field|exist: false
+                    && target == &FieldValue::Boolean(true) { // true for field|exist: false
                     return true
                 }
                 false
@@ -226,7 +226,8 @@ impl Field {
             // 2. match_all = true: all conditions fired => return true
             self.modifier.match_all
         } else {
-            if self.modifier.match_modifier == Some(MatchModifier::Exists) {
+            // we need to capture if a field we don't want to exist doesn't exist
+            if self.modifier.match_modifier == Some(MatchModifier::Exists) { 
                 for val in self.values.iter() {
                     if val == &FieldValue::Boolean(false) {
                         return true;

--- a/src/field.rs
+++ b/src/field.rs
@@ -141,23 +141,24 @@ impl Field {
                     .map(FieldValue::String)
                     .collect();
             }
-            None => { // no value transformers have been used, so convert everything to lower case for caseless matches
-                self.values = self
-                    .values
-                    .iter()
-                    .map(|val| FieldValue::String(value_to_lowercase(val)))
-                    .collect()
-            }
+            None => {}
+        }
+        if !self.modifier.cased {
+            self.values = self
+                .values
+                .iter()
+                .map(|val| FieldValue::String(value_to_lowercase(val)))
+                .collect()
         }
 
         Ok(())
     }    
 
     pub(crate) fn compare(&self, target: &FieldValue, value: &FieldValue) -> bool {
-        let t = if !self.modifier.cased {
-            &FieldValue::String(target.value_to_string().to_lowercase())
-        } else {
+        let t = if self.modifier.cased { // was case insensitive matching specified?
             target
+        } else {
+            &FieldValue::String(target.value_to_string().to_lowercase())
         };
         match self.modifier.match_modifier {
             Some(MatchModifier::Contains) => t.contains(value),

--- a/src/field.rs
+++ b/src/field.rs
@@ -3,7 +3,6 @@ mod transformation;
 mod value;
 
 pub use modifier::*;
-use transformation::value_to_lowercase;
 pub use value::*;
 
 use crate::error::ParserError;
@@ -146,19 +145,6 @@ impl Field {
             }
         }
 
-        if !self.modifier.cased {
-            match self.modifier.match_modifier {
-                Some(MatchModifier::Contains)
-                | Some(MatchModifier::StartsWith)
-                | Some(MatchModifier::EndsWith) => {
-                    self.values = self.values.iter()
-                        .map(|v| FieldValue::String(value_to_lowercase(v)))
-                        .collect()
-                },
-                _ => {}
-            }
-        }        
-
         Ok(())
     }    
 
@@ -167,16 +153,15 @@ impl Field {
             Some(MatchModifier::Contains) | 
             Some(MatchModifier::StartsWith) | 
             Some(MatchModifier::EndsWith) => {
-                let t = if self.modifier.cased {
-                    target
+                let v = if self.modifier.cased {
+                    value
                 } else {
-                    &FieldValue::String(target.value_to_string().to_lowercase())
+                    &FieldValue::String(format!("(?i){}", value.value_to_string()))
                 };
-                
                 match self.modifier.match_modifier {
-                    Some(MatchModifier::Contains) => t.contains(value),
-                    Some(MatchModifier::StartsWith) => t.starts_with(value),
-                    Some(MatchModifier::EndsWith) => t.ends_with(value),
+                    Some(MatchModifier::Contains) => target.contains(v),
+                    Some(MatchModifier::StartsWith) => target.starts_with(v),
+                    Some(MatchModifier::EndsWith) => target.ends_with(v),
                     _ => false, // Just a fallback case
                 }
             },

--- a/src/field.rs
+++ b/src/field.rs
@@ -141,15 +141,15 @@ impl Field {
                     .map(FieldValue::String)
                     .collect();
             }
-            None => {
-                if !self.modifier.cased {
-                    self.values = self
-                        .values
-                        .iter()
-                        .map(|val| FieldValue::String(value_to_lowercase(val)))
-                        .collect()
-                }
-            }
+            None => {}
+        }
+
+        if !self.modifier.cased {
+            self.values = self
+                .values
+                .iter()
+                .map(|val| FieldValue::String(value_to_lowercase(val)))
+                .collect()
         }
 
         Ok(())

--- a/src/field/modifier.rs
+++ b/src/field/modifier.rs
@@ -29,12 +29,14 @@ pub enum ValueTransformer {
     Base64(Option<Utf16Modifier>),
     Base64offset(Option<Utf16Modifier>),
     Windash,
+    Cased,
 }
 
 #[derive(Debug, Default)]
 pub struct Modifier {
     pub(crate) match_all: bool,
     pub(crate) fieldref: bool,
+    pub(crate) cased: bool,
     pub(crate) match_modifier: Option<MatchModifier>,
     pub(crate) value_transformer: Option<ValueTransformer>,
 }

--- a/src/field/modifier.rs
+++ b/src/field/modifier.rs
@@ -156,9 +156,9 @@ impl FromStr for Modifier {
             }
         }
     
-        let (is_valid, base, windash_or_cased) = is_valid_transformers(&result.value_transformer);
+        let (is_valid, base, dash_or_case) = is_valid_transformers(&result.value_transformer);
         if !is_valid {
-            return Err(Self::Err::ConflictingModifiers(base, windash_or_cased));
+            return Err(Self::Err::ConflictingModifiers(base, dash_or_case));
         }
 
         if let (Some(MatchModifier::Re) | Some(MatchModifier::Cidr), Some(_)) =

--- a/src/field/modifier.rs
+++ b/src/field/modifier.rs
@@ -9,6 +9,7 @@ pub enum MatchModifier {
     Contains,
     StartsWith,
     EndsWith,
+    Exists,
     Gt,
     Gte,
     Lt,
@@ -107,6 +108,10 @@ impl FromStr for Modifier {
                 result.match_modifier = Some(match_modifier);
                 continue;
             }
+            match result.match_modifier {
+                Some(MatchModifier::Exists) => break,
+                _ => {}
+            }
 
             match Utf16Modifier::from_str(&s) {
                 Ok(m) => match utf16_modifier {
@@ -161,7 +166,9 @@ impl FromStr for Modifier {
             return Err(Self::Err::ConflictingModifiers(base, dash_or_case));
         }
 
-        if let (Some(MatchModifier::Re) | Some(MatchModifier::Cidr), Some(_)) =
+        if let (Some(MatchModifier::Re) 
+            | Some(MatchModifier::Cidr)
+            | Some(MatchModifier::Exists), Some(_)) =
             (&result.match_modifier, &result.value_transformer.iter().flatten().next())
         {
             return Err(Self::Err::StandaloneViolation(

--- a/src/field/transformation.rs
+++ b/src/field/transformation.rs
@@ -3,9 +3,9 @@ use base64::engine::general_purpose::STANDARD_NO_PAD;
 use base64::Engine;
 use std::collections::HashMap;
 
-pub fn value_to_lowercase(input: &FieldValue) -> String {
-    return input.value_to_string().to_lowercase()
-}
+// pub fn value_to_lowercase(input: &FieldValue) -> String {
+//     return input.value_to_string().to_lowercase()
+// }
 
 pub fn encode_base64(input: &FieldValue, utf16modifier: &Option<Utf16Modifier>) -> String {
     let mut encoded = match utf16modifier {

--- a/src/field/transformation.rs
+++ b/src/field/transformation.rs
@@ -3,6 +3,10 @@ use base64::engine::general_purpose::STANDARD_NO_PAD;
 use base64::Engine;
 use std::collections::HashMap;
 
+pub fn value_to_lowercase(input: &FieldValue) -> String {
+    return input.value_to_string().to_lowercase()
+}
+
 pub fn encode_base64(input: &FieldValue, utf16modifier: &Option<Utf16Modifier>) -> String {
     let mut encoded = match utf16modifier {
         Some(Utf16Modifier::Utf16le) => STANDARD_NO_PAD.encode(

--- a/src/field/value.rs
+++ b/src/field/value.rs
@@ -216,8 +216,6 @@ impl FieldValue {
             reg_ex
         };
     
-        // need to account for the "cased" Sigma modifier
-        
         reg_ex.is_match(&target)
     }
     

--- a/src/field/value.rs
+++ b/src/field/value.rs
@@ -217,7 +217,8 @@ impl FieldValue {
         };
     
         // need to account for the "cased" Sigma modifier
-        reg_ex.is_match(&target.to_lowercase())
+        
+        reg_ex.is_match(&target)
     }
     
 

--- a/src/field/value.rs
+++ b/src/field/value.rs
@@ -177,11 +177,8 @@ impl FieldValue {
     }
 
     fn get_regex(pattern:&str) -> Option<Regex> {
-        let cached_regex = {
-            let cache = PATTERN_CACHE.lock().unwrap();
-            cache.get(pattern).cloned()
-        };
-        return cached_regex
+        let cache = PATTERN_CACHE.lock().unwrap();
+        cache.get(pattern).cloned()
     }
 
     fn insert_regex(pattern:&str) -> Regex {

--- a/src/field/value.rs
+++ b/src/field/value.rs
@@ -197,7 +197,13 @@ impl FieldValue {
         } else {
             let mut regex_pattern = String::new();
             let mut chars = pattern.chars().peekable();
-    
+            
+            // Skip the "(?i)" for regex case insensitive search
+            if pattern.starts_with("(?i)") {
+                regex_pattern.push_str("(?i)");
+                chars.nth(3);
+            }
+            
             while let Some(ch) = chars.next() {
                 match ch {
                     '\\' => {
@@ -212,13 +218,13 @@ impl FieldValue {
                     _ => regex_pattern.push_str(&regex::escape(&ch.to_string())),
                 }
             }
-    
+
             let full_pattern = match pattern_type {
                 MatchModifier::StartsWith => format!("^{}", regex_pattern),
                 MatchModifier::EndsWith => format!("{}$", regex_pattern),
                 _ => regex_pattern,
             };
-    
+
             let r = Self::insert_regex(&full_pattern);
             r
         };


### PR DESCRIPTION
Updated contains, startswith, and endswith to handle simple '*' and '?' pattern matching via conversion to regex. Created a hashmap to store already compiled regexes.

Added requirement for `lazy_static` for caching already compiled regex's.

Still learning the code so I don't trust myself entirely in what I've changed / added here.