### PR TITLE
Add support for `cased` modifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,11 @@ A Rust library for parsing and evaluating Sigma rules to create custom detection
 
 ## Features
 
-- Supports all[^1] [sigma modifiers](https://sigmahq.io/docs/basics/modifiers.html) including the unofficial `fieldref`
-  modifier
-- Supports the whole [Sigma condition](https://sigmahq.io/docs/basics/conditions.html) syntax using Pratt parsing
+- Supports the [Sigma condition](https://sigmahq.io/docs/basics/conditions.html) syntax using Pratt parsing
+- Wide support for [sigma modifiers](https://sigmahq.io/docs/basics/modifiers.html)
 - Written in 100% safe Rust
 - Daily automated security audit of dependencies
 - Extensive test suite
-
-[^1]: Except the [expand](https://sigmahq.io/docs/basics/modifiers.html#expand) modifier.
 
 ## Example
 

--- a/src/detection.rs
+++ b/src/detection.rs
@@ -122,24 +122,20 @@ impl Detection {
                 .selections
                 .keys()
                 .filter(|name| glob_match(s, name))
-                .map(|name| self.evaluate_selection(name, lookup, event))
-                .any(|b| b),
+                .any(|name| self.evaluate_selection(name, lookup, event)),
             Ast::OneOfThem => self
                 .selections
                 .keys()
-                .map(|name| self.evaluate_selection(name, lookup, event))
-                .any(|b| b),
+                .any(|name| self.evaluate_selection(name, lookup, event)),
             Ast::AllOf(s) => self
                 .selections
                 .keys()
                 .filter(|name| glob_match(s, name))
-                .map(|name| self.evaluate_selection(name, lookup, event))
-                .all(|b| b),
+                .all(|name| self.evaluate_selection(name, lookup, event)),
             Ast::AllOfThem => self
                 .selections
                 .keys()
-                .map(|name| self.evaluate_selection(name, lookup, event))
-                .all(|b| b),
+                .all(|name| self.evaluate_selection(name, lookup, event)),
             Ast::Not(ref operand) => !self.eval(event, operand, lookup),
             Ast::Or(ref left, ref right) => {
                 self.eval(event, left, lookup) || self.eval(event, right, lookup)

--- a/src/field/modifier.rs
+++ b/src/field/modifier.rs
@@ -35,6 +35,7 @@ pub enum ValueTransformer {
 pub struct Modifier {
     pub(crate) match_all: bool,
     pub(crate) fieldref: bool,
+    pub(crate) cased: bool,
     pub(crate) match_modifier: Option<MatchModifier>,
     pub(crate) value_transformer: Option<ValueTransformer>,
 }
@@ -66,6 +67,10 @@ impl FromStr for Modifier {
             }
             if s == "fieldref" {
                 result.fieldref = true;
+                continue;
+            }
+            if s == "cased" {
+                result.cased = true;
                 continue;
             }
 

--- a/tests/matching.rs
+++ b/tests/matching.rs
@@ -121,3 +121,43 @@ fn test_match_null_fields() {
     assert!(rule.is_match(&event_1));
     assert!(!rule.is_match(&event_2));
 }
+
+#[test]
+fn test_match_cased_contains_modifier() {
+    let yaml = r#"
+    title: Rule with cased modifier
+    logsource:
+    detection:
+        selection:
+            - File|contains|cased: evil
+        condition: selection
+    "#;
+
+    let rule = rule_from_yaml(yaml).unwrap();
+    let event_1 = Event::from([("File", "c:\\evil.exe")]);
+    let event_2 = Event::from([("File", "C:\\EVIL.exe")]);
+
+    assert!(rule.is_match(&event_1));
+    assert!(!rule.is_match(&event_2));
+}
+
+#[test]
+fn test_match_cased_windash() {
+    let yaml = r#"
+    title: Rule with cased modifier
+    logsource:
+    detection:
+        selection:
+            - CMD|windash|cased: -force
+        condition: selection
+    "#;
+
+    let rule = rule_from_yaml(yaml).unwrap();
+    let event_1 = Event::from([("CMD", "-force")]);
+    let event_2 = Event::from([("CMD", "-FORCE")]);
+    let event_3 = Event::from([("CMD", "/force")]);
+
+    assert!(rule.is_match(&event_1));
+    assert!(!rule.is_match(&event_2));
+    assert!(rule.is_match(&event_3));
+}


### PR DESCRIPTION
This PR adds support for the `cased` modifier and will fix #11.

As an additional change,  the matching will be performed **case-insensitive** by default to comply with the Sigma standard:

> Sigma's default behavior is case-insensitive matching.

Source: https://sigmahq.io/docs/basics/modifiers.html#cased