### PR TITLE
Use trait instead of Event

### DIFF
--- a/src/detection.rs
+++ b/src/detection.rs
@@ -3,7 +3,7 @@ mod lexer;
 
 use crate::detection::ast::Ast;
 use crate::error::ParserError;
-use crate::event::{Event, QueryableEvent};
+use crate::event::QueryableEvent;
 use crate::selection::Selection;
 use crate::wildcard::match_tokenized;
 use serde::Deserialize;
@@ -155,6 +155,7 @@ impl Detection {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::Event;
 
     #[test]
     fn test_missing_identifier() {

--- a/src/detection.rs
+++ b/src/detection.rs
@@ -3,7 +3,7 @@ mod lexer;
 
 use crate::detection::ast::Ast;
 use crate::error::ParserError;
-use crate::event::Event;
+use crate::event::{Event, QueryableEvent};
 use crate::selection::Selection;
 use crate::wildcard::match_tokenized;
 use serde::Deserialize;
@@ -92,15 +92,15 @@ impl Detection {
         Ok(())
     }
 
-    pub(crate) fn evaluate(&self, event: &Event) -> bool {
+    pub(crate) fn evaluate<E: QueryableEvent>(&self, event: &E) -> bool {
         self.eval(event, &self.ast, &mut HashMap::new())
     }
 
-    fn evaluate_selection(
+    fn evaluate_selection<E: QueryableEvent>(
         &self,
         name: &str,
         lookup: &mut HashMap<String, bool>,
-        event: &Event,
+        event: &E,
     ) -> bool {
         if let Some(e) = lookup.get(name) {
             *e
@@ -115,7 +115,12 @@ impl Detection {
         }
     }
 
-    fn eval(&self, event: &Event, ast: &Ast, lookup: &mut HashMap<String, bool>) -> bool {
+    fn eval<E: QueryableEvent>(
+        &self,
+        event: &E,
+        ast: &Ast,
+        lookup: &mut HashMap<String, bool>,
+    ) -> bool {
         match ast {
             Ast::Selection(s) => self.evaluate_selection(s, lookup, event),
             Ast::OneOf(s) => self

--- a/src/event.rs
+++ b/src/event.rs
@@ -176,6 +176,21 @@ where
     }
 }
 
+/// `QueryableEvent` is used to run the sigma rules on top of any
+/// struct that can be queryable, instead of creating an `Event`
+/// which allocates a HashMap, this trait allows users to wrap their
+/// own data structures and avoid an allocation. Another possibility is
+/// to query files or databases if needed.
+pub trait QueryableEvent {
+    /// Iterate over the key-value pairs in the event
+    fn iter(&self) -> impl Iterator<Item = (&String, &EventValue)>;
+
+    /// Get the value for a key in the event
+    fn get(&self, key: &str) -> Option<&EventValue>;
+
+    fn values(&self) -> impl Iterator<Item = &EventValue>;
+}
+
 /// The `Event` struct represents a log event.
 ///
 /// It is a collection of key-value pairs
@@ -212,11 +227,9 @@ where
 }
 
 impl Event {
-    /// Create a new empty event
     pub fn new() -> Self {
         Self::default()
     }
-
     /// Insert a key-value pair into the event.
     /// If the key already exists, the value will be replaced.
     ///
@@ -236,14 +249,16 @@ impl Event {
     {
         self.inner.insert(key.into(), value.into());
     }
+}
 
+impl QueryableEvent for Event {
     /// Iterate over the key-value pairs in the event
-    pub fn iter(&self) -> impl Iterator<Item = (&String, &EventValue)> {
+    fn iter(&self) -> impl Iterator<Item = (&String, &EventValue)> {
         self.inner.iter()
     }
 
     /// Get the value for a key in the event
-    pub fn get(&self, key: &str) -> Option<&EventValue> {
+    fn get(&self, key: &str) -> Option<&EventValue> {
         if let Some(ev) = self.inner.get(key) {
             return Some(ev);
         }
@@ -264,7 +279,7 @@ impl Event {
         None
     }
 
-    pub fn values(&self) -> impl Iterator<Item = &EventValue> {
+    fn values(&self) -> impl Iterator<Item = &EventValue> {
         self.inner.values()
     }
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -230,6 +230,7 @@ impl Event {
     pub fn new() -> Self {
         Self::default()
     }
+
     /// Insert a key-value pair into the event.
     /// If the key already exists, the value will be replaced.
     ///

--- a/src/field.rs
+++ b/src/field.rs
@@ -8,7 +8,7 @@ pub use value::*;
 use crate::basevalue::BaseValue;
 use crate::error::ParserError;
 use crate::error::ParserError::{IPParsing, InvalidYAML};
-use crate::event::{Event, EventValue, QueryableEvent};
+use crate::event::{EventValue, QueryableEvent};
 use crate::field::transformation::{encode_base64, encode_base64_offset, windash_variations};
 use crate::field::ValueTransformer::{Base64, Base64offset, Windash};
 use crate::wildcard::{tokenize, WildcardToken};
@@ -212,6 +212,7 @@ impl Field {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::Event;
 
     #[test]
     fn test_parse_name_only() {

--- a/src/field.rs
+++ b/src/field.rs
@@ -8,7 +8,7 @@ pub use value::*;
 use crate::basevalue::BaseValue;
 use crate::error::ParserError;
 use crate::error::ParserError::{IPParsing, InvalidYAML};
-use crate::event::{Event, EventValue};
+use crate::event::{Event, EventValue, QueryableEvent};
 use crate::field::transformation::{encode_base64, encode_base64_offset, windash_variations};
 use crate::field::ValueTransformer::{Base64, Base64offset, Windash};
 use crate::wildcard::{tokenize, WildcardToken};
@@ -167,7 +167,7 @@ impl Field {
         Ok(())
     }
 
-    pub(crate) fn evaluate(&self, event: &Event) -> bool {
+    pub(crate) fn evaluate<E: QueryableEvent>(&self, event: &E) -> bool {
         let Some(event_value) = event.get(&self.name) else {
             return matches!(self.modifier.exists, Some(false));
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ mod selection;
 mod wildcard;
 
 pub use event::Event;
+pub use event::QueryableEvent;
 pub use rule::Rule;
 
 /// Parse a rule from a YAML string

--- a/src/selection.rs
+++ b/src/selection.rs
@@ -3,7 +3,7 @@ use crate::error::SelectionError::{
     InvalidKeywordSelection, InvalidSelectionType, MixedKeywordAndFieldlist,
     SelectionContainsNoFields,
 };
-use crate::event::Event;
+use crate::event::{Event, QueryableEvent};
 use crate::field::Field;
 use serde::Deserialize;
 use serde_norway::Value;
@@ -17,7 +17,7 @@ pub struct FieldGroup {
 }
 
 impl FieldGroup {
-    fn evaluate(&self, event: &Event) -> bool {
+    fn evaluate<E: QueryableEvent>(&self, event: &E) -> bool {
         self.fields.iter().all(|field| field.evaluate(event))
     }
 }
@@ -116,7 +116,7 @@ impl TryFrom<Value> for Selection {
 }
 
 impl Selection {
-    pub(crate) fn evaluate(&self, event: &Event) -> bool {
+    pub(crate) fn evaluate<E: QueryableEvent>(&self, event: &E) -> bool {
         match &self {
             Self::Keyword(keywords) => event
                 .values()

--- a/src/selection.rs
+++ b/src/selection.rs
@@ -3,7 +3,7 @@ use crate::error::SelectionError::{
     InvalidKeywordSelection, InvalidSelectionType, MixedKeywordAndFieldlist,
     SelectionContainsNoFields,
 };
-use crate::event::{Event, QueryableEvent};
+use crate::event::QueryableEvent;
 use crate::field::Field;
 use serde::Deserialize;
 use serde_norway::Value;

--- a/tests/matching.rs
+++ b/tests/matching.rs
@@ -1,4 +1,4 @@
-use sigma_rust::{rule_from_yaml, Event, QueryableEvent, Rule};
+use sigma_rust::{rule_from_yaml, Event, Rule};
 
 #[test]
 fn test_match_rule_with_keywords() {

--- a/tests/matching.rs
+++ b/tests/matching.rs
@@ -1,4 +1,4 @@
-use sigma_rust::{rule_from_yaml, Event, Rule};
+use sigma_rust::{rule_from_yaml, Event, QueryableEvent, Rule};
 
 #[test]
 fn test_match_rule_with_keywords() {
@@ -136,7 +136,7 @@ fn test_match_null_fields() {
 
     let rule = rule_from_yaml(yaml).unwrap();
     let event_1 = Event::from([("OriginalFileName", "RUNDLL32.EXE")]);
-    let mut event_2 = Event::new();
+    let mut event_2 = Event::default();
     event_2.insert("Image", "c:\\rundll32.exe");
     event_2.insert("CommandLine", None);
 


### PR DESCRIPTION
This would be a breaking change. Today, the `Event` is a concrete type that internally uses a `HashMap`.  This may be a problem for low-latency applications, where having to create an event from other data structures may be problematic (image applications that have different rules engines and may need to allocate to each different rule engine "event"). 

Ultimately, what we really want is the ability to query the data structure, so anything that conforms to such an API should work for the crate. This PR introduces a `QueryableEvent` trait, which is implemented by `Event`. The `QueryableEvent` can be implemented by the crate users for their different structs instead of forcing them to convert to a `sigma_rust::Event`.